### PR TITLE
Added dynamic weeks per month month rendering in yearly view

### DIFF
--- a/src/basic/YearView.js
+++ b/src/basic/YearView.js
@@ -922,9 +922,7 @@ var YearView = FC.YearView = View.extend({
 			renderRange.end.add(1, 'week').startOf('week'); // exclusively move backwards
 
 			// calculate weeks in month or display 6 weeks
-                	var rStart = moment(renderRange.start).utc().startOf('month');
-                	var rEnd = moment(renderRange.end).utc().endOf('month');
-                	var nrofWeeks = moment.duration(rEnd - rStart).weeks() + 1;
+                	var nrofWeeks = renderRange.end.diff(renderRange.start, 'weeks');
 			var rowCnt = Math.ceil( // could be partial weeks due to hiddenDays
 				renderRange.end.diff(renderRange.start, 'weeks', true) // dontRound=true
 			);

--- a/src/basic/YearView.js
+++ b/src/basic/YearView.js
@@ -921,11 +921,14 @@ var YearView = FC.YearView = View.extend({
 			// make end-of-week if not already
 			renderRange.end.add(1, 'week').startOf('week'); // exclusively move backwards
 
-			//ensure 6 weeks
+			// calculate weeks in month or display 6 weeks
+                	var rStart = moment(renderRange.start).utc().startOf('month');
+                	var rEnd = moment(renderRange.end).utc().endOf('month');
+                	var nrofWeeks = moment.duration(rEnd - rStart).weeks() + 1;
 			var rowCnt = Math.ceil( // could be partial weeks due to hiddenDays
 				renderRange.end.diff(renderRange.start, 'weeks', true) // dontRound=true
 			);
-			renderRange.end.add(6 - rowCnt, 'weeks');
+                	renderRange.end.add(((this.isFixedWeeks) ? 6 : nrofWeeks) - rowCnt, 'weeks');
 
 			dayGrid.setRange(renderRange);
 


### PR DESCRIPTION
Respects isFixedWeeks bool declared in events array. Calculates appropriate weeks in a month if isFixedWeeks===true, otherwise defaults to static 6 weeks in every month.